### PR TITLE
configure Instana Agent repository conditionally

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,11 @@
 # like setting database credentials in the configuration.yml file.
 instana_agent_run: True
 
+# The Instana Agent package repository will be configured only, when set
+# to true. E.g. disable this, when you want have your own package repo/mirror
+# setup.
+instana_agent_configure_repo: True
+
 # This mode specifies the mode under which the Instana agent should run.
 # Possible values are "apm", "infrastructure" and "off".
 # See:: https://docs.instana.io/quick_start/agent_configuration/#agent-mode

--- a/tasks/files.yml
+++ b/tasks/files.yml
@@ -11,7 +11,7 @@
     src: 'templates/maven_settings.j2'
     group: 'root'
     owner: 'root'
-    mode: 644
+    mode: 0644
   notify: 'ensure the agent is running'
 
 - name: 'template maven proxy + mirror settings config'
@@ -20,7 +20,7 @@
     src: 'templates/pax_maven_cfg.j2'
     group: 'root'
     owner: 'root'
-    mode: 644
+    mode: 0644
   notify: instana-agent-restart
 
 - name: 'template agent backend config'
@@ -29,7 +29,7 @@
     src: 'templates/agent_backend.j2'
     group: 'root'
     owner: 'root'
-    mode: 644
+    mode: 0644
 
 - name: 'template agent sensor version pin config'
   template:
@@ -37,7 +37,7 @@
     src: 'templates/agent_bootstrap.j2'
     group: 'root'
     owner: 'root'
-    mode: 644
+    mode: 0644
 
 - name: 'template agent update config'
   template:
@@ -45,7 +45,7 @@
     src: 'templates/agent_update.j2'
     group: 'root'
     owner: 'root'
-    mode: 644
+    mode: 0644
 
 - name: 'template agent configuration'
   template:
@@ -53,14 +53,14 @@
     src: 'templates/agent_config.j2'
     group: 'root'
     owner: 'root'
-    mode: 644
+    mode: 0644
 
 - name: 'create agent meta config'
   file:
     path: "{{ config_prefix }}main.config.Agent.cfg"
     owner: 'root'
     group: 'root'
-    mode: 644
+    mode: 0644
     state: 'file'
   notify: instana-agent-restart
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,7 @@
+# encoding: utf-8
+---
+
+- name: 'install agent package'
+  package:
+    name: "instana-agent-{{ instana_agent_flavor }}"
+    state: 'latest'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,5 +32,7 @@
     instana_agent_agent_key == ''
 
 - include: repo.yml
+  when: instana_agent_configure_repo
+- include: install.yml
 - include: init.yml
 - include: files.yml

--- a/tasks/repo.yml
+++ b/tasks/repo.yml
@@ -38,8 +38,3 @@
     gpgcheck: no
     name: 'Instana-Agent'
   when: ansible_pkg_mgr == 'yum'
-
-- name: 'install agent package'
-  package:
-    name: "instana-agent-{{ instana_agent_flavor }}"
-    state: 'latest'

--- a/templates/agent_update.j2
+++ b/templates/agent_update.j2
@@ -1,10 +1,7 @@
 # Instana Update Manager configuration.
-
 # AUTO for automatic updates with given schedule. OFF for no automatic updates.
 mode = {{ (instana_agent_updates_enabled) | ternary("AUTO", "OFF") }}
-
 # DAY for daily, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY
 every = {{ instana_agent_updates_interval }}
-
 # Time is hh:mm in 24 hours format.
 at = {{ instana_agent_updates_time }}


### PR DESCRIPTION
The new switch `instana_agent_configure_repo` allows to disable the configuration of the Instana Agent repository. This comes in useful, when a custom local Instana Agent repo mirror is setup and configured otherwise.