### PR TITLE
Systemd fixes

### DIFF
--- a/tasks/init.yml
+++ b/tasks/init.yml
@@ -13,7 +13,7 @@
   file:
     path: "{{ systemd_srv_dir }}"
     group: 'root'
-    mode: 644
+    mode: 0755
     owner: 'root'
     state: 'directory'
   when: ansible_service_mgr == 'systemd'
@@ -23,7 +23,7 @@
     dest: "{{ systemd_srv_dir }}/10-resources.conf"
     src: "templates/systemd_resources.j2"
     group: 'root'
-    mode: 644
+    mode: 0644
     owner: 'root'
   notify: reload-systemd
   when: >

--- a/templates/systemd_resources.j2
+++ b/templates/systemd_resources.j2
@@ -1,7 +1,7 @@
 [Service]
 {% if instana_agent_limit_cpu_enabled %}
 CPUAccounting=true
-CPUQuota={{ ( instana_agent_limit_cpu_quota * 100 ) }}%
+CPUQuota={{ (instana_agent_limit_cpu_quota * 100)|int }}%
 {% endif %}
 {% if instana_agent_limit_memory_enabled %}
 MemoryAccounting=true


### PR DESCRIPTION
The following messages were in syslog after running the playbook:
```
Oct 10 06:12:18 postgresql1 systemd[1]: Configuration file /etc/systemd/system/instana-agent.service.d/10-resources.conf is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.

Oct 10 06:12:18 postgresql1 systemd[1]: /etc/systemd/system/instana-agent.service.d/10-resources.conf:3: CPU quota '50.0%' invalid. Ignoring.
```
My changes fix these issues by setting the correct file modes and using the correct syntax for `CPUQuota` in the service dropin file.