### PR TITLE
Fix usage of a conditional bare variable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,7 @@
     instana_agent_agent_key == ''
 
 - include: repo.yml
-  when: instana_agent_configure_repo
+  when: instana_agent_configure_repo|bool
 - include: install.yml
 - include: init.yml
 - include: files.yml


### PR DESCRIPTION
Ansible v2.8 introduced a deprecation warning for conditional bare variables, this change removes the warning 
https://docs.ansible.com/ansible/latest/reference_appendices/config.html#conditional-bare-vars

[DEPRECATION WARNING]: evaluating instana_agent_configure_repo as a bare variable, this behaviour will go away and you
might need to add |bool to the expression in the future. Also see CONDITIONAL_BARE_VARS configuration toggle.. This
feature will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.