### PR TITLE
Added custom agent configuration variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -93,6 +93,10 @@ instana_agent_zone: ""
 # See:: https://docs.instana.io/quick_start/agent_configuration/#tags
 instana_agent_tags: []
 
+# If you need to add additional settings to the Instana agent configuration.yaml file
+# Possible values: a block of custom agent configuration settings 
+instana_agent_configuration_customblock: ""
+
 # We support running and updating the Instana agent through a proxy setup.
 # See:: https://docs.instana.io/quick_start/on_prem/on_prem_agent_repository/#sonatype-nexus-proxy-setup
 instana_agent_proxy_enabled: False

--- a/templates/agent_config.j2
+++ b/templates/agent_config.j2
@@ -180,3 +180,8 @@ com.instana.plugin.generic.hardware:
 #    DATABASE_NAME_2:
 #      user: '' #default is 'SYSTEM'
 #      password: ''
+
+{% if instana_agent_configuration_customblock != '' %}
+# Advanced Settings
+{{ instana_agent_configuration_customblock }}
+{% endif %}


### PR DESCRIPTION
Added agent custom variable to keep idempotency when using custom/advanced settings in the agent configuration.
This is useful if you're adding extra changes to the configuration.yaml that aren't immediately supported by this ansible playbook